### PR TITLE
fix(DateTimeField): remove undefined Android refs and narrow iOS disp…

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,7 +16,15 @@ export default function RootLayout(): React.ReactElement {
     (async () => {
       try {
         await Notifications.setNotificationHandler({
-          handleNotification: async () => ({ shouldShowAlert: true, shouldPlaySound: true, shouldSetBadge: false }),
+          handleNotification: async () => ({
+            // New fields required by NotificationBehavior
+            shouldShowBanner: true,
+            shouldShowList: true,
+            shouldPlaySound: true,
+            shouldSetBadge: false,
+            // Keep for backwards compatibility on older platforms
+            shouldShowAlert: true,
+          }),
         });
 
         const { status } = await Notifications.requestPermissionsAsync();

--- a/components/DateTimeField.tsx
+++ b/components/DateTimeField.tsx
@@ -8,7 +8,7 @@ type Props = {
   label?: string;
   value: Date;
   onChange: (next: Date) => void;
-  display?: 'default' | 'spinner' | 'calendar' | 'clock' | 'inline';
+  display?: 'default' | 'spinner' | 'compact' | 'inline';
 };
 
 /**
@@ -19,7 +19,8 @@ type Props = {
 export default function DateTimeField({ label = 'Date & time', value, onChange, display }: Props): React.ReactElement {
   const [show, setShow] = useState<boolean>(false);
   const [picking, setPicking] = useState<boolean>(false);
-  const disp = display ?? (Platform.OS === 'ios' ? 'inline' : 'default');
+  const disp: 'default' | 'compact' | 'inline' | 'spinner' =
+    display ?? (Platform.OS === 'ios' ? 'inline' : 'default');
 
   function onChangePicker(event: DateTimePickerEvent, date?: Date): void {
     // iOS inline picker only
@@ -48,7 +49,7 @@ export default function DateTimeField({ label = 'Date & time', value, onChange, 
   }
 
   // Android: step 1 — date, then step 2 — time
-  function onChangeAndroidDate(event: any, selectedDate?: Date): void {
+  /* function onChangeAndroidDate(event: any, selectedDate?: Date): void {
     // Close date picker regardless of outcome
     setShowAndroidDate(false);
 
@@ -64,9 +65,9 @@ export default function DateTimeField({ label = 'Date & time', value, onChange, 
       // Ensure next picker shows after current closes
       setTimeout(() => setShowAndroidTime(true), 0);
     }
-  }
+  } */
 
-  function onChangeAndroidTime(event: any, selectedTime?: Date): void {
+  /* function onChangeAndroidTime(event: any, selectedTime?: Date): void {
     // Close time picker regardless of outcome
     setShowAndroidTime(false);
 
@@ -85,15 +86,15 @@ export default function DateTimeField({ label = 'Date & time', value, onChange, 
     } else {
       setTempAndroidDate(null);
     }
-  }
+  } */
 
-  const onPressOpen = (): void => {
+  /* const onPressOpen = (): void => {
     if (Platform.OS === 'ios') {
       setShowIOS(true);
     } else {
       setShowAndroidDate(true);
     }
-  };
+  }; */
 
   return (
     <View style={styles.wrap}>


### PR DESCRIPTION
…lay typing

chore(notifications): update NotificationBehavior handler for Expo 53 (shouldShowBanner/shouldShowList)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Notifications now show banners and appear in the notification list, with existing alert/sound behavior preserved.
  * Date/time field adds a new “compact” display option.
* Refactor
  * Android date/time selection streamlined to a single, simplified picker flow.
  * Display modes updated: removed “calendar” and “clock”; available options are now “default”, “spinner”, “compact”, and “inline”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->